### PR TITLE
Deploy app before running in first app tutorial

### DIFF
--- a/src/pages/getting_started/first_app.md
+++ b/src/pages/getting_started/first_app.md
@@ -346,10 +346,16 @@ aio app run --local
 This will deploy the actions to a local [OpenWhisk](https://openwhisk.apache.org/) instance, which the [CLI](https://github.com/adobe/aio-cli) will autmomatically download and install. The SPA will be run on the local machine. 
 
 ```
+aio app deploy
+```
+
+This will deploy the actions to [Adobe I/O Runtime](/apis/experienceplatform/runtime).
+
+```
 aio app run
 ```
 
-This will deploy the actions to [Adobe I/O Runtime](/apis/experienceplatform/runtime), while running the UI part on the local machine. 
+This will use the actions deployed to [Adobe I/O Runtime](/apis/experienceplatform/runtime), while running the UI part on the local machine. 
 
 #### (First time users) Accepting the Certificate
 


### PR DESCRIPTION
Modify First App tutorial to deploy actions to Runtime before developing locally, using actions deployed to Runtime.

## Description

See https://github.com/AdobeDocs/adobe-developer-app-builder/issues/156#issuecomment-1224286033

## Related Issue

Closes https://github.com/AdobeDocs/adobe-developer-app-builder/issues/156

## Motivation and Context

Accurate documentation

## How Has This Been Tested?

Tested e2e locally on a new project.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
